### PR TITLE
Team C Default Certificate Order Update (After Regression Test nalang i pull ty ty)

### DIFF
--- a/src/TeamDComponents/TeamD_Css/content.css
+++ b/src/TeamDComponents/TeamD_Css/content.css
@@ -50,7 +50,7 @@
 .pagination-custom {
   background-color: transparent !important;
   border-color: transparent !important;
-  position: fixed;
+  position: absolute;
   bottom: 3rem;
   text-align: center; /* Center pagination horizontally */
 }

--- a/src/TeamDComponents/Team_D_Content.jsx
+++ b/src/TeamDComponents/Team_D_Content.jsx
@@ -44,19 +44,36 @@ const Team_D_Content = () => {
     handleCategoryChange(DateIssued); // Trigger filtering on initial render
   }, [pdfFileNames]); // Trigger filtering when pdfFileNames changes
 
+  //old version default ascending order
+  // const handleCategoryChange = (value) => {
+  //   setDateIssued(value);
+  //   if (value === "recent") {
+  //     // Filter recent certificates
+  //     const filtered = pdfFileNames.filter(
+  //       (cert) => FilterDate(cert.date_issued) === "recent"
+  //     );
+  //     setFilteredCertificates(filtered);
+  //   } else {
+  //     // Display all certificates
+  //     setFilteredCertificates(pdfFileNames);
+  //   }
+  // };
+
+
+//new version displaying it descending order
   const handleCategoryChange = (value) => {
     setDateIssued(value);
     if (value === "recent") {
-      // Filter recent certificates
-      const filtered = pdfFileNames.filter(
-        (cert) => FilterDate(cert.date_issued) === "recent"
-      );
-      setFilteredCertificates(filtered);
+        // Filter recent certificates
+        const filtered = pdfFileNames
+            .filter(cert => FilterDate(cert.date_issued) === "recent")
+            .sort((a, b) => new Date(b.date_issued) - new Date(a.date_issued)); // Sort by date in descending order
+        setFilteredCertificates(filtered);
     } else {
-      // Display all certificates
-      setFilteredCertificates(pdfFileNames);
+        // Display all certificates
+        setFilteredCertificates(pdfFileNames);
     }
-  };
+};
 
   if (value !== null) {
     // Value exists, you can use it


### PR DESCRIPTION
- changed position from fixed to absolute so pagination won't overlap with the certificates.
- changed the order of recent to descending so I can show the most recent certificates.
- not yet testable, completion of regression testing is required.